### PR TITLE
feat(model): auto-cast return of getModelElementById

### DIFF
--- a/xml-model/src/main/java/org/camunda/bpm/model/xml/ModelInstance.java
+++ b/xml-model/src/main/java/org/camunda/bpm/model/xml/ModelInstance.java
@@ -80,7 +80,7 @@ public interface ModelInstance {
    * @param id  the id of the element
    * @return the element with the id or null
    */
-  ModelElementInstance getModelElementById(String id);
+  <T extends ModelElementInstance> T getModelElementById(String id);
 
   /**
    * Find all elements of a type.

--- a/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/ModelInstanceImpl.java
+++ b/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/ModelInstanceImpl.java
@@ -17,6 +17,7 @@ import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.ModelException;
 import org.camunda.bpm.model.xml.ModelInstance;
 import org.camunda.bpm.model.xml.impl.instance.ModelElementInstanceImpl;
+import org.camunda.bpm.model.xml.impl.util.ModelTypeException;
 import org.camunda.bpm.model.xml.impl.util.ModelUtil;
 import org.camunda.bpm.model.xml.instance.DomDocument;
 import org.camunda.bpm.model.xml.instance.DomElement;
@@ -92,14 +93,19 @@ public class ModelInstanceImpl implements ModelInstance {
     return elementType;
   }
 
-  public ModelElementInstance getModelElementById(String id) {
+  @SuppressWarnings("unchecked")
+  public <T extends ModelElementInstance> T getModelElementById(String id) {
     if (id == null) {
       return null;
     }
 
     DomElement element = document.getElementById(id);
     if(element != null) {
-      return ModelUtil.getModelElement(element, this);
+      try {
+        return (T) ModelUtil.getModelElement(element, this);
+      } catch (ClassCastException e) {
+        throw new ModelTypeException("Cannot cast element to desired type", e);
+      }
     } else {
       return null;
     }

--- a/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelTypeException.java
+++ b/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/util/ModelTypeException.java
@@ -34,4 +34,8 @@ public class ModelTypeException extends ModelException {
     super("Illegal value "+value+" for type "+type);
   }
 
+  public ModelTypeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
 }


### PR DESCRIPTION
Auto-cast the return value of getModelElementById() to the desired
subtype of ModelElementInstance.

Makes it possible to write

  Animal a = modelInstance.getModelElementById("a");

instead of

  Animal a = (Animal) modelInstance.getModelElementById("a");
