### PR TITLE
Support for DataObject and DataObjectReference

### DIFF
--- a/src/main/java/org/camunda/bpm/model/bpmn/Bpmn.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/Bpmn.java
@@ -72,6 +72,7 @@ import org.camunda.bpm.model.bpmn.impl.instance.di.PlaneImpl;
 import org.camunda.bpm.model.bpmn.impl.instance.di.ShapeImpl;
 import org.camunda.bpm.model.bpmn.impl.instance.di.StyleImpl;
 import org.camunda.bpm.model.bpmn.impl.instance.di.WaypointImpl;
+import org.camunda.bpm.model.bpmn.instance.DataObject;
 import org.camunda.bpm.model.bpmn.instance.Definitions;
 import org.camunda.bpm.model.bpmn.instance.Process;
 import org.camunda.bpm.model.xml.Model;
@@ -313,6 +314,8 @@ public class Bpmn {
     DataOutputRefs.registerType(bpmnModelBuilder);
     DataPath.registerType(bpmnModelBuilder);
     DataStateImpl.registerType(bpmnModelBuilder);
+    DataObjectImpl.registerType(bpmnModelBuilder);
+    DataObjectReferenceImpl.registerType(bpmnModelBuilder);
     DefinitionsImpl.registerType(bpmnModelBuilder);
     DocumentationImpl.registerType(bpmnModelBuilder);
     EndEventImpl.registerType(bpmnModelBuilder);

--- a/src/main/java/org/camunda/bpm/model/bpmn/impl/BpmnModelConstants.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/impl/BpmnModelConstants.java
@@ -83,6 +83,8 @@ public final class BpmnModelConstants {
   public static final String BPMN_ELEMENT_TO = "to";
   public static final String BPMN_ELEMENT_ASSIGNMENT = "assignment";
   public static final String BPMN_ELEMENT_ITEM_AWARE_ELEMENT = "itemAwareElement";
+  public static final String BPMN_ELEMENT_DATA_OBJECT = "dataObject";
+  public static final String BPMN_ELEMENT_DATA_OBJECT_REFERENCE = "dataObjectReference";
   public static final String BPMN_ELEMENT_DATA_INPUT = "dataInput";
   public static final String BPMN_ELEMENT_FORMAL_EXPRESSION = "formalExpression";
   public static final String BPMN_ELEMENT_DATA_ASSOCIATION = "dataAssociation";
@@ -336,6 +338,7 @@ public final class BpmnModelConstants {
   public static final String BPMN_ATTRIBUTE_ESCALATION_CODE = "escalationCode";
   public static final String BPMN_ATTRIBUTE_ESCALATION_REF = "escalationRef";
   public static final String BPMN_ATTRIBUTE_EVENT_GATEWAY_TYPE = "eventGatewayType";
+  public static final String BPMN_ATTRIBUTE_DATA_OBJECT_REF = "dataObjectRef";
 
   /** DC */
 

--- a/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/DataObjectImpl.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/DataObjectImpl.java
@@ -1,0 +1,93 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.model.bpmn.impl.instance;
+
+import org.camunda.bpm.model.bpmn.instance.*;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+import org.camunda.bpm.model.xml.type.child.ChildElement;
+import org.camunda.bpm.model.xml.type.child.SequenceBuilder;
+import org.camunda.bpm.model.xml.type.reference.AttributeReference;
+
+import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.*;
+import static org.camunda.bpm.model.xml.type.ModelElementTypeBuilder.ModelTypeInstanceProvider;
+
+/**
+ * The BPMN dataObject element
+ *
+ * @author Dario Campagna
+ */
+public class DataObjectImpl extends FlowElementImpl implements DataObject {
+
+  protected static AttributeReference<ItemDefinition> itemSubjectRefAttribute;
+  protected static ChildElement<DataState> dataStateChild;
+  protected static Attribute<Boolean> isCollectionAttribute;
+
+  public static void registerType(ModelBuilder modelBuilder) {
+    ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(DataObject.class, BPMN_ELEMENT_DATA_OBJECT)
+      .namespaceUri(BPMN20_NS)
+      .extendsType(FlowElement.class)
+      .instanceProvider(new ModelTypeInstanceProvider<DataObject>() {
+        public DataObject newInstance(ModelTypeInstanceContext instanceContext) {
+          return new DataObjectImpl(instanceContext);
+        }
+      });
+
+    itemSubjectRefAttribute = typeBuilder.stringAttribute(BPMN_ATTRIBUTE_ITEM_SUBJECT_REF)
+      .qNameAttributeReference(ItemDefinition.class)
+      .build();
+
+    SequenceBuilder sequenceBuilder = typeBuilder.sequence();
+
+    dataStateChild = sequenceBuilder.element(DataState.class)
+      .build();
+
+    isCollectionAttribute = typeBuilder.booleanAttribute(BPMN_ATTRIBUTE_IS_COLLECTION)
+      .defaultValue(false)
+      .build();
+
+    typeBuilder.build();
+  }
+
+  public DataObjectImpl(ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public ItemDefinition getItemSubject() {
+    return itemSubjectRefAttribute.getReferenceTargetElement(this);
+  }
+
+  public void setItemSubject(ItemDefinition itemSubject) {
+    itemSubjectRefAttribute.setReferenceTargetElement(this, itemSubject);
+  }
+
+  public DataState getDataState() {
+    return dataStateChild.getChild(this);
+  }
+
+  public void setDataState(DataState dataState) {
+    dataStateChild.setChild(this, dataState);
+  }
+
+  public boolean isCollection() {
+    return isCollectionAttribute.getValue(this);
+  }
+
+  public void setCollection(boolean isCollection) {
+    isCollectionAttribute.setValue(this, isCollection);
+  }
+
+}

--- a/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/DataObjectReferenceImpl.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/DataObjectReferenceImpl.java
@@ -1,0 +1,89 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.model.bpmn.impl.instance;
+
+import org.camunda.bpm.model.bpmn.instance.*;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+import org.camunda.bpm.model.xml.type.child.ChildElement;
+import org.camunda.bpm.model.xml.type.child.SequenceBuilder;
+import org.camunda.bpm.model.xml.type.reference.AttributeReference;
+
+import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.*;
+
+/**
+ * @author Dario Campagna
+ */
+public class DataObjectReferenceImpl extends FlowElementImpl implements DataObjectReference {
+
+  protected static AttributeReference<ItemDefinition> itemSubjectRefAttribute;
+  protected static ChildElement<DataState> dataStateChild;
+  protected static AttributeReference<DataObject> dataObjectRefAttribute;
+
+  public static void registerType(ModelBuilder modelBuilder) {
+    ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(DataObjectReference.class, BPMN_ELEMENT_DATA_OBJECT_REFERENCE)
+      .namespaceUri(BPMN20_NS)
+      .extendsType(FlowElement.class)
+      .instanceProvider(new ModelElementTypeBuilder.ModelTypeInstanceProvider<DataObjectReference>() {
+        public DataObjectReference newInstance(ModelTypeInstanceContext instanceContext) {
+          return new DataObjectReferenceImpl(instanceContext);
+        }
+      });
+
+    itemSubjectRefAttribute = typeBuilder.stringAttribute(BPMN_ATTRIBUTE_ITEM_SUBJECT_REF)
+      .qNameAttributeReference(ItemDefinition.class)
+      .build();
+
+    SequenceBuilder sequenceBuilder = typeBuilder.sequence();
+
+    dataStateChild = sequenceBuilder.element(DataState.class)
+      .build();
+
+    dataObjectRefAttribute = typeBuilder.stringAttribute(BPMN_ATTRIBUTE_DATA_OBJECT_REF)
+      .qNameAttributeReference(DataObject.class)
+      .build();
+
+    typeBuilder.build();
+  }
+
+  public DataObjectReferenceImpl(ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public ItemDefinition getItemSubject() {
+    return itemSubjectRefAttribute.getReferenceTargetElement(this);
+  }
+
+  public void setItemSubject(ItemDefinition itemSubject) {
+    itemSubjectRefAttribute.setReferenceTargetElement(this, itemSubject);
+  }
+
+  public DataState getDataState() {
+    return dataStateChild.getChild(this);
+  }
+
+  public void setDataState(DataState dataState) {
+    dataStateChild.setChild(this, dataState);
+  }
+
+  public DataObject getDataObject() {
+    return dataObjectRefAttribute.getReferenceTargetElement(this);
+  }
+
+  public void setDataObject(DataObject dataObject) {
+    dataObjectRefAttribute.setReferenceTargetElement(this, dataObject);
+  }
+}

--- a/src/main/java/org/camunda/bpm/model/bpmn/instance/DataObject.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/instance/DataObject.java
@@ -1,0 +1,31 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.model.bpmn.instance;
+
+/**
+ * The BPMN dataObject element
+ *
+ * @author Dario Campagna
+ */
+public interface DataObject extends FlowElement, ItemAwareElement {
+
+  String getName();
+
+  void setName(String name);
+
+  boolean isCollection();
+
+  void setCollection(boolean isCollection);
+
+}

--- a/src/main/java/org/camunda/bpm/model/bpmn/instance/DataObjectReference.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/instance/DataObjectReference.java
@@ -1,0 +1,31 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.model.bpmn.instance;
+
+/**
+ * The BPMN dataObjectReference element
+ *
+ * @author Dario Campagna
+ */
+public interface DataObjectReference extends FlowElement, ItemAwareElement {
+
+  String getName();
+
+  void setName(String name);
+
+  DataObject getDataObject();
+
+  void setDataObject(DataObject dataObject);
+
+}

--- a/src/test/java/org/camunda/bpm/model/bpmn/DataObjectsTest.java
+++ b/src/test/java/org/camunda/bpm/model/bpmn/DataObjectsTest.java
@@ -1,0 +1,72 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.model.bpmn;
+
+import org.camunda.bpm.model.bpmn.instance.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dario Campagna
+ */
+public class DataObjectsTest {
+
+  private static BpmnModelInstance modelInstance;
+
+  @BeforeClass
+  public static void parseModel() {
+    modelInstance = Bpmn.readModelFromStream(DataObjectsTest.class.getResourceAsStream("DataObjectTest.bpmn"));
+  }
+
+  @Test
+  public void testGetDataObject() {
+    DataObject dataObject = modelInstance.getModelElementById("_21");
+    ItemDefinition itemDefinition = modelInstance.getModelElementById("_100");
+    assertThat(dataObject).isNotNull();
+    assertThat(dataObject.getName()).isEqualTo("DataObject _21");
+    assertThat(dataObject.isCollection()).isFalse();
+    assertThat(dataObject.getItemSubject()).isEqualTo(itemDefinition);
+  }
+
+  @Test
+  public void testGetDataObjectReference() {
+    DataObjectReference dataObjectReference = modelInstance.getModelElementById("_dataRef_7");
+    DataObject dataObject = modelInstance.getModelElementById("_7");
+    assertThat(dataObjectReference).isNotNull();
+    assertThat(dataObjectReference.getName()).isNull();
+    assertThat(dataObjectReference.getDataObject()).isEqualTo(dataObject);
+  }
+
+  @Test
+  public void testDataObjectReferenceAsDataAssociationSource() {
+    ScriptTask scriptTask = modelInstance.getModelElementById("_3");
+    DataObjectReference dataObjectReference = modelInstance.getModelElementById("_dataRef_11");
+    DataInputAssociation dataInputAssociation = scriptTask.getDataInputAssociations().iterator().next();
+    Collection<ItemAwareElement> sources = dataInputAssociation.getSources();
+    assertThat(sources.size()).isEqualTo(1);
+    assertThat(sources.iterator().next()).isEqualTo(dataObjectReference);
+  }
+
+  @Test
+  public void testDataObjectReferenceAsDataAssociationTarget() {
+    ScriptTask scriptTask = modelInstance.getModelElementById("_3");
+    DataObjectReference dataObjectReference = modelInstance.getModelElementById("_dataRef_7");
+    DataOutputAssociation dataOutputAssociation = scriptTask.getDataOutputAssociations().iterator().next();
+    assertThat(dataOutputAssociation.getTarget()).isEqualTo(dataObjectReference);
+  }
+}

--- a/src/test/java/org/camunda/bpm/model/bpmn/instance/DataObjectReferenceTest.java
+++ b/src/test/java/org/camunda/bpm/model/bpmn/instance/DataObjectReferenceTest.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.model.bpmn.instance;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * @author Dario Campagna
+ */
+public class DataObjectReferenceTest extends BpmnModelElementInstanceTest {
+
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(FlowElement.class, false);
+  }
+
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Arrays.asList(
+      new ChildElementAssumption(DataState.class, 0, 1)
+    );
+  }
+
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+      new AttributeAssumption("itemSubjectRef"),
+      new AttributeAssumption("dataObjectRef")
+    );
+  }
+}

--- a/src/test/java/org/camunda/bpm/model/bpmn/instance/DataObjectTest.java
+++ b/src/test/java/org/camunda/bpm/model/bpmn/instance/DataObjectTest.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.model.bpmn.instance;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * @author Dario Campagna
+ */
+public class DataObjectTest extends BpmnModelElementInstanceTest {
+
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(FlowElement.class, false);
+  }
+
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Arrays.asList(
+      new ChildElementAssumption(DataState.class, 0, 1)
+    );
+  }
+
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+      new AttributeAssumption("itemSubjectRef"),
+      new AttributeAssumption("isCollection", false, false, false)
+    );
+  }
+}

--- a/src/test/resources/org/camunda/bpm/model/bpmn/DataObjectTest.bpmn
+++ b/src/test/resources/org/camunda/bpm/model/bpmn/DataObjectTest.bpmn
@@ -1,0 +1,94 @@
+<semantics:definitions
+        xmlns:xsd='http://www.w3.org/2001/XMLSchema'
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns:semantics='http://www.omg.org/spec/BPMN/20100524/MODEL'
+        xsi:schemaLocation='http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd'
+        targetNamespace='http://camunda.org/test' expressionLanguage='http://www.w3.org/1999/XPath'
+        typeLanguage='http://www.w3.org/2001/XMLSchema' id='_0' name='definitions'>
+    <semantics:itemDefinition id='_100' itemKind='Information' structureRef='xsd:int'
+                              isCollection='false'></semantics:itemDefinition>
+    <semantics:itemDefinition id='_101' itemKind='Information' structureRef='xsd:long'
+                              isCollection='false'></semantics:itemDefinition>
+    <semantics:itemDefinition id='_103' itemKind='Information' structureRef='xsd:float'
+                              isCollection='false'></semantics:itemDefinition>
+    <semantics:itemDefinition id='_104' itemKind='Information' structureRef='xsd:double'
+                              isCollection='false'></semantics:itemDefinition>
+    <semantics:itemDefinition id='_105' itemKind='Information' structureRef='xsd:boolean'
+                              isCollection='false'></semantics:itemDefinition>
+    <semantics:itemDefinition id='_106' itemKind='Information' structureRef='xsd:anyURI'
+                              isCollection='false'></semantics:itemDefinition>
+    <semantics:itemDefinition id='_107' itemKind='Information' structureRef='xsd:string'
+                              isCollection='false'></semantics:itemDefinition>
+    <semantics:resource id='_resource_user' name='user'></semantics:resource>
+    <semantics:resource id='_resource_Batman' name='Batman'></semantics:resource>
+    <semantics:process id='_1' name='process'>
+        <semantics:startEvent id='_2' name='StartEvent _2'>
+            <semantics:outgoing>_4</semantics:outgoing>
+        </semantics:startEvent>
+        <semantics:endEvent id='_5' name='EndEvent _5'>
+            <semantics:incoming>_6</semantics:incoming>
+        </semantics:endEvent>
+        <semantics:scriptTask id='_3' name='Script Task _3' scriptFormat='text/javascript'>
+            <semantics:incoming>_4</semantics:incoming>
+            <semantics:outgoing>_6</semantics:outgoing>
+            <semantics:ioSpecification id='_15'>
+                <semantics:dataInput id='_16' name='x' itemSubjectRef='_103' isCollection='false'>
+                </semantics:dataInput>
+                <semantics:dataInput id='_17' name='y' isCollection='false'></semantics:dataInput>
+                <semantics:dataInput id='_18' name='z' itemSubjectRef='_105' isCollection='false'></semantics:dataInput>
+                <semantics:dataOutput id='_19' name='a' isCollection='false'></semantics:dataOutput>
+                <semantics:dataOutput id='_20' name='b' isCollection='false'></semantics:dataOutput>
+                <semantics:inputSet>
+                    <semantics:dataInputRefs>_16</semantics:dataInputRefs>
+                    <semantics:dataInputRefs>_17</semantics:dataInputRefs>
+                    <semantics:dataInputRefs>_18</semantics:dataInputRefs>
+                </semantics:inputSet>
+                <semantics:outputSet>
+                    <semantics:dataOutputRefs>_19</semantics:dataOutputRefs>
+                    <semantics:dataOutputRefs>_20</semantics:dataOutputRefs>
+                </semantics:outputSet>
+            </semantics:ioSpecification>
+            <semantics:dataInputAssociation id='_13'>
+                <semantics:sourceRef>_dataRef_11</semantics:sourceRef>
+                <semantics:targetRef>_16</semantics:targetRef>
+            </semantics:dataInputAssociation>
+            <semantics:dataInputAssociation id='_14'>
+                <semantics:sourceRef>_dataRef_12</semantics:sourceRef>
+                <semantics:targetRef>_17</semantics:targetRef>
+            </semantics:dataInputAssociation>
+            <semantics:dataInputAssociation id='_22'>
+                <semantics:sourceRef>_dataRef_21</semantics:sourceRef>
+                <semantics:targetRef>_18</semantics:targetRef>
+            </semantics:dataInputAssociation>
+            <semantics:dataOutputAssociation id='_8'>
+                <semantics:sourceRef>_20</semantics:sourceRef>
+                <semantics:targetRef>_dataRef_7</semantics:targetRef>
+            </semantics:dataOutputAssociation>
+            <semantics:dataOutputAssociation id='_24'>
+                <semantics:sourceRef>_19</semantics:sourceRef>
+                <semantics:targetRef>_dataRef_23</semantics:targetRef>
+            </semantics:dataOutputAssociation>
+            <semantics:script>function foo(x,y,z){
+                var a = x + y;
+                var b = z + y;
+                }
+            </semantics:script>
+        </semantics:scriptTask>
+        <semantics:dataObject id='_7' name='DataObject _7' isCollection='false'>
+        </semantics:dataObject>
+        <semantics:dataObject id='_11' name='DataObject _11' itemSubjectRef='_101'
+                              isCollection='false'>
+        </semantics:dataObject>
+        <semantics:dataObject id='_12' name='DataObject _12' isCollection='false'></semantics:dataObject>
+        <semantics:dataObject id='_21' name='DataObject _21' itemSubjectRef='_100'
+                              isCollection='false'></semantics:dataObject>
+        <semantics:dataObject id='_23' name='DataObject _23' isCollection='false'></semantics:dataObject>
+        <semantics:sequenceFlow id='_4' sourceRef='_2' targetRef='_3'></semantics:sequenceFlow>
+        <semantics:sequenceFlow id='_6' sourceRef='_3' targetRef='_5'></semantics:sequenceFlow>
+        <semantics:dataObjectReference id='_dataRef_7' dataObjectRef='_7'></semantics:dataObjectReference>
+        <semantics:dataObjectReference id='_dataRef_11' dataObjectRef='_11'></semantics:dataObjectReference>
+        <semantics:dataObjectReference id='_dataRef_12' dataObjectRef='_12'></semantics:dataObjectReference>
+        <semantics:dataObjectReference id='_dataRef_21' dataObjectRef='_21'></semantics:dataObjectReference>
+        <semantics:dataObjectReference id='_dataRef_23' dataObjectRef='_23'></semantics:dataObjectReference>
+    </semantics:process>
+</semantics:definitions>


### PR DESCRIPTION
- Added `DataObject` interface and `DataObjectImpl` class in order to support BPMN 2.0 DataObjects
- Added `DataObjectReference` interface and `DataObjectReferenceImpl` class in order to support BPMN 2.0 DataObjectReferences
