### PR TITLE
feat(bpmn-model) create a BpmnModelInstnace with a copy of the underlying DomDocument

### DIFF
--- a/src/main/java/org/camunda/bpm/model/bpmn/Bpmn.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/Bpmn.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.camunda.bpm.model.bpmn.builder.ProcessBuilder;
+import org.camunda.bpm.model.bpmn.impl.BpmnModelInstanceImpl;
 import org.camunda.bpm.model.bpmn.impl.BpmnParser;
 import org.camunda.bpm.model.bpmn.impl.instance.*;
 import org.camunda.bpm.model.bpmn.impl.instance.ProcessImpl;
@@ -79,6 +80,7 @@ import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.ModelException;
 import org.camunda.bpm.model.xml.ModelParseException;
 import org.camunda.bpm.model.xml.ModelValidationException;
+import org.camunda.bpm.model.xml.impl.ModelImpl;
 import org.camunda.bpm.model.xml.impl.instance.ModelElementInstanceImpl;
 import org.camunda.bpm.model.xml.impl.util.IoUtil;
 import org.camunda.bpm.model.xml.impl.util.ModelUtil;
@@ -180,6 +182,17 @@ public class Bpmn {
   public static BpmnModelInstance createEmptyModel() {
     return INSTANCE.doCreateEmptyModel();
   }
+  
+  /**
+   * Copies the BPMN model instance but not the model. So only the wrapped DOM document is cloned.
+   * Changes of the model are persistent between multiple model instances.
+   * 
+   * @param bpmnModelInstance The model instance to be copied
+   * @return the new BPMN model instance
+   */
+  public static BpmnModelInstance copyOfBpmnModelInstance(BpmnModelInstance bpmnModelInstance){
+    return INSTANCE.doCopyOfBpmnModelInstance(bpmnModelInstance);
+  }
 
   public static ProcessBuilder createProcess() {
     BpmnModelInstance modelInstance = INSTANCE.doCreateEmptyModel();
@@ -268,6 +281,10 @@ public class Bpmn {
 
   protected BpmnModelInstance doCreateEmptyModel() {
     return bpmnParser.getEmptyModel();
+  }
+  
+  protected BpmnModelInstance doCopyOfBpmnModelInstance(BpmnModelInstance bpmnModelInstance) {
+    return new BpmnModelInstanceImpl((ModelImpl) INSTANCE.getBpmnModel(), INSTANCE.getBpmnModelBuilder(), bpmnModelInstance.getDocument().clone());
   }
 
   protected void doRegisterTypes(ModelBuilder bpmnModelBuilder) {


### PR DESCRIPTION
Hi,

I recently had a use case where I needed to create a copy of a ```BpmnModelInstance```, which can be done by converting the instance to a ```String```, creating an ```InputStream``` from it and then reading a ```BpmnModelInstance``` from the stream. I thought that it might be a good idea to have this functionality in the API.

I was not sure whether to put this in the ```BpmnParser```, ```Bpmn``` or some other place, so I put it in the ```Bpmn```. Let me know what you think.