### PR TITLE
CAM-10399: add timeout task listener

### DIFF
--- a/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -525,4 +525,28 @@ public abstract class AbstractBaseElementBuilder<B extends AbstractBaseElementBu
       }
     }
   }
+
+  protected TimerEventDefinition createTimeCycle(String timerCycle) {
+    TimeCycle timeCycle = createInstance(TimeCycle.class);
+    timeCycle.setTextContent(timerCycle);
+    TimerEventDefinition timerDefinition = createInstance(TimerEventDefinition.class);
+    timerDefinition.setTimeCycle(timeCycle);
+    return timerDefinition;
+  }
+
+  protected TimerEventDefinition createTimeDate(String timerDate) {
+    TimeDate timeDate = createInstance(TimeDate.class);
+    timeDate.setTextContent(timerDate);
+    TimerEventDefinition timerDefinition = createInstance(TimerEventDefinition.class);
+    timerDefinition.setTimeDate(timeDate);
+    return timerDefinition;
+  }
+
+  protected TimerEventDefinition createTimeDuration(String timerDuration) {
+    TimeDuration timeDuration = createInstance(TimeDuration.class);
+    timeDuration.setTextContent(timerDuration);
+    TimerEventDefinition timerDefinition = createInstance(TimerEventDefinition.class);
+    timerDefinition.setTimeDuration(timeDuration);
+    return timerDefinition;
+  }
 }

--- a/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractCatchEventBuilder.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractCatchEventBuilder.java
@@ -17,17 +17,11 @@
 package org.camunda.bpm.model.bpmn.builder;
 
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.camunda.bpm.model.bpmn.instance.BoundaryEvent;
 import org.camunda.bpm.model.bpmn.instance.CatchEvent;
 import org.camunda.bpm.model.bpmn.instance.CompensateEventDefinition;
 import org.camunda.bpm.model.bpmn.instance.ConditionalEventDefinition;
-import org.camunda.bpm.model.bpmn.instance.EventDefinition;
 import org.camunda.bpm.model.bpmn.instance.MessageEventDefinition;
 import org.camunda.bpm.model.bpmn.instance.SignalEventDefinition;
-import org.camunda.bpm.model.bpmn.instance.TimeCycle;
-import org.camunda.bpm.model.bpmn.instance.TimeDate;
-import org.camunda.bpm.model.bpmn.instance.TimeDuration;
-import org.camunda.bpm.model.bpmn.instance.TimerEventDefinition;
 
 /**
  * @author Sebastian Menski
@@ -84,13 +78,7 @@ public abstract class AbstractCatchEventBuilder<B extends  AbstractCatchEventBui
    * @return the builder object
    */
   public B timerWithDate(String timerDate) {
-    TimeDate timeDate = createInstance(TimeDate.class);
-    timeDate.setTextContent(timerDate);
-
-    TimerEventDefinition timerEventDefinition = createInstance(TimerEventDefinition.class);
-    timerEventDefinition.setTimeDate(timeDate);
-
-    element.getEventDefinitions().add(timerEventDefinition);
+    element.getEventDefinitions().add(createTimeDate(timerDate));
 
     return myself;
   }
@@ -102,13 +90,7 @@ public abstract class AbstractCatchEventBuilder<B extends  AbstractCatchEventBui
    * @return the builder object
    */
   public B timerWithDuration(String timerDuration) {
-    TimeDuration timeDuration = createInstance(TimeDuration.class);
-    timeDuration.setTextContent(timerDuration);
-
-    TimerEventDefinition timerEventDefinition = createInstance(TimerEventDefinition.class);
-    timerEventDefinition.setTimeDuration(timeDuration);
-
-    element.getEventDefinitions().add(timerEventDefinition);
+    element.getEventDefinitions().add(createTimeDuration(timerDuration));
 
     return myself;
   }
@@ -120,13 +102,7 @@ public abstract class AbstractCatchEventBuilder<B extends  AbstractCatchEventBui
    * @return the builder object
    */
   public B timerWithCycle(String timerCycle) {
-    TimeCycle timeCycle = createInstance(TimeCycle.class);
-    timeCycle.setTextContent(timerCycle);
-
-    TimerEventDefinition timerEventDefinition = createInstance(TimerEventDefinition.class);
-    timerEventDefinition.setTimeCycle(timeCycle);
-
-    element.getEventDefinitions().add(timerEventDefinition);
+    element.getEventDefinitions().add(createTimeCycle(timerCycle));
 
     return myself;
   }

--- a/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -19,8 +19,9 @@ package org.camunda.bpm.model.bpmn.builder;
 import java.util.List;
 
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.impl.BpmnModelConstants;
+import org.camunda.bpm.model.bpmn.instance.TimerEventDefinition;
 import org.camunda.bpm.model.bpmn.instance.UserTask;
-import org.camunda.bpm.model.bpmn.instance.camunda.CamundaExecutionListener;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaFormData;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaFormField;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaTaskListener;
@@ -134,7 +135,7 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
   public B camundaFormHandlerClass(Class camundaFormHandlerClass) {
     return camundaFormHandlerClass(camundaFormHandlerClass.getName());
   }
-  
+
   /**
    * Sets the camunda form handler class attribute.
    *
@@ -190,7 +191,7 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
   public B camundaTaskListenerClass(String eventName, Class listenerClass) {
     return camundaTaskListenerClass(eventName, listenerClass.getName());
   }
-  
+
   /**
    * Add a class based task listener with specified event name
    *
@@ -226,5 +227,83 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
     addExtensionElement(executionListener);
 
     return myself;
+  }
+
+  @SuppressWarnings("rawtypes")
+  public B camundaTaskListenerClassTimeoutWithCycle(String id, Class listenerClass, String timerCycle) {
+    return camundaTaskListenerClassTimeoutWithCycle(id, listenerClass.getName(), timerCycle);
+  }
+
+  @SuppressWarnings("rawtypes")
+  public B camundaTaskListenerClassTimeoutWithDate(String id, Class listenerClass, String timerDate) {
+    return camundaTaskListenerClassTimeoutWithDate(id, listenerClass.getName(), timerDate);
+  }
+
+  @SuppressWarnings("rawtypes")
+  public B camundaTaskListenerClassTimeoutWithDuration(String id, Class listenerClass, String timerDuration) {
+    return camundaTaskListenerClassTimeoutWithDuration(id, listenerClass.getName(), timerDuration);
+  }
+
+  public B camundaTaskListenerClassTimeoutWithCycle(String id, String fullQualifiedClassName, String timerCycle) {
+    return createCamundaTaskListenerClassTimeout(id, fullQualifiedClassName, createTimeCycle(timerCycle));
+  }
+
+  public B camundaTaskListenerClassTimeoutWithDate(String id, String fullQualifiedClassName, String timerDate) {
+    return createCamundaTaskListenerClassTimeout(id, fullQualifiedClassName, createTimeDate(timerDate));
+  }
+
+  public B camundaTaskListenerClassTimeoutWithDuration(String id, String fullQualifiedClassName, String timerDuration) {
+    return createCamundaTaskListenerClassTimeout(id, fullQualifiedClassName, createTimeDuration(timerDuration));
+  }
+
+  public B camundaTaskListenerExpressionTimeoutWithCycle(String id, String expression, String timerCycle) {
+    return createCamundaTaskListenerExpressionTimeout(id, expression, createTimeCycle(timerCycle));
+  }
+
+  public B camundaTaskListenerExpressionTimeoutWithDate(String id, String expression, String timerDate) {
+    return createCamundaTaskListenerExpressionTimeout(id, expression, createTimeDate(timerDate));
+  }
+
+  public B camundaTaskListenerExpressionTimeoutWithDuration(String id, String expression, String timerDuration) {
+    return createCamundaTaskListenerExpressionTimeout(id, expression, createTimeDuration(timerDuration));
+  }
+
+  public B camundaTaskListenerDelegateExpressionTimeoutWithCycle(String id, String delegateExpression, String timerCycle) {
+    return createCamundaTaskListenerDelegateExpressionTimeout(id, delegateExpression, createTimeCycle(timerCycle));
+  }
+
+  public B camundaTaskListenerDelegateExpressionTimeoutWithDate(String id, String delegateExpression, String timerDate) {
+    return createCamundaTaskListenerDelegateExpressionTimeout(id, delegateExpression, createTimeDate(timerDate));
+  }
+
+  public B camundaTaskListenerDelegateExpressionTimeoutWithDuration(String id, String delegateExpression, String timerDuration) {
+    return createCamundaTaskListenerDelegateExpressionTimeout(id, delegateExpression, createTimeDuration(timerDuration));
+  }
+
+  protected B createCamundaTaskListenerClassTimeout(String id, String fullQualifiedClassName, TimerEventDefinition timerDefinition) {
+    CamundaTaskListener executionListener = createCamundaTaskListenerTimeout(id, timerDefinition);
+    executionListener.setCamundaClass(fullQualifiedClassName);
+    return myself;
+  }
+
+  protected B createCamundaTaskListenerExpressionTimeout(String id, String expression, TimerEventDefinition timerDefinition) {
+    CamundaTaskListener executionListener = createCamundaTaskListenerTimeout(id, timerDefinition);
+    executionListener.setCamundaExpression(expression);
+    return myself;
+  }
+
+  protected B createCamundaTaskListenerDelegateExpressionTimeout(String id, String delegateExpression, TimerEventDefinition timerDefinition) {
+    CamundaTaskListener executionListener = createCamundaTaskListenerTimeout(id, timerDefinition);
+    executionListener.setCamundaDelegateExpression(delegateExpression);
+    return myself;
+  }
+
+  protected CamundaTaskListener createCamundaTaskListenerTimeout(String id, TimerEventDefinition timerDefinition) {
+    CamundaTaskListener executionListener = createInstance(CamundaTaskListener.class);
+    executionListener.setAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ID, id, true);
+    executionListener.setCamundaEvent("timeout");
+    executionListener.addChildElement(timerDefinition);
+    addExtensionElement(executionListener);
+    return executionListener;
   }
 }

--- a/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/camunda/CamundaTaskListenerImpl.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/camunda/CamundaTaskListenerImpl.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.model.bpmn.impl.instance.camunda;
 import java.util.Collection;
 
 import org.camunda.bpm.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import org.camunda.bpm.model.bpmn.instance.TimerEventDefinition;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaField;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaScript;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaTaskListener;
@@ -51,6 +52,7 @@ public class CamundaTaskListenerImpl extends BpmnModelElementInstanceImpl implem
   protected static Attribute<String> camundaDelegateExpressionAttribute;
   protected static ChildElementCollection<CamundaField> camundaFieldCollection;
   protected static ChildElement<CamundaScript> camundaScriptChild;
+  protected static ChildElementCollection<TimerEventDefinition> timeoutCollection;
 
   public static void registerType(ModelBuilder modelBuilder) {
     ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(CamundaTaskListener.class, CAMUNDA_ELEMENT_TASK_LISTENER)
@@ -83,6 +85,9 @@ public class CamundaTaskListenerImpl extends BpmnModelElementInstanceImpl implem
       .build();
 
     camundaScriptChild = sequenceBuilder.element(CamundaScript.class)
+      .build();
+
+    timeoutCollection = sequenceBuilder.element(TimerEventDefinition.class)
       .build();
 
     typeBuilder.build();
@@ -134,6 +139,10 @@ public class CamundaTaskListenerImpl extends BpmnModelElementInstanceImpl implem
 
   public void setCamundaScript(CamundaScript camundaScript) {
     camundaScriptChild.setChild(this, camundaScript);
+  }
+
+  public Collection<TimerEventDefinition> getTimeouts() {
+    return timeoutCollection.get(this);
   }
 
 }

--- a/src/main/java/org/camunda/bpm/model/bpmn/instance/camunda/CamundaTaskListener.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/instance/camunda/CamundaTaskListener.java
@@ -17,7 +17,7 @@
 package org.camunda.bpm.model.bpmn.instance.camunda;
 
 import org.camunda.bpm.model.bpmn.instance.BpmnModelElementInstance;
-
+import org.camunda.bpm.model.bpmn.instance.TimerEventDefinition;
 import java.util.Collection;
 
 /**
@@ -48,5 +48,7 @@ public interface CamundaTaskListener extends BpmnModelElementInstance {
   CamundaScript getCamundaScript();
 
   void setCamundaScript(CamundaScript camundaScript);
+
+  Collection<TimerEventDefinition> getTimeouts();
 
 }

--- a/src/test/java/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.java
+++ b/src/test/java/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.java
@@ -86,6 +86,7 @@ import org.camunda.bpm.model.bpmn.instance.SendTask;
 import org.camunda.bpm.model.bpmn.instance.SequenceFlow;
 import org.camunda.bpm.model.bpmn.instance.ServiceTask;
 import org.camunda.bpm.model.bpmn.instance.StartEvent;
+import org.camunda.bpm.model.bpmn.instance.TimerEventDefinition;
 import org.camunda.bpm.model.bpmn.instance.UserTask;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaConnector;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaConnectorId;
@@ -801,6 +802,15 @@ public class CamundaExtensionsTest {
     CamundaField field = taskListener.getCamundaFields().iterator().next();
     assertThat(field.getCamundaName()).isEqualTo(TEST_STRING_XML);
     assertThat(field.getCamundaString().getTextContent()).isEqualTo(TEST_STRING_XML);
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNotNull();
+    assertThat(timeout.getTimeDuration().getRawTextContent()).isEqualTo("PT1H");
   }
 
   @Test

--- a/src/test/java/org/camunda/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/src/test/java/org/camunda/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -1637,6 +1637,342 @@ public class ProcessBuilderTest {
   }
 
   @Test
+  public void testCamundaTimeoutCycleTaskListenerByClassName() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerClassTimeoutWithCycle("timeout-1", "aClass", "R/PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaClass()).isEqualTo("aClass");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNotNull();
+    assertThat(timeout.getTimeCycle().getRawTextContent()).isEqualTo("R/PT1H");
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutDateTaskListenerByClassName() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerClassTimeoutWithDate("timeout-1", "aClass", "2019-09-09T12:12:12")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaClass()).isEqualTo("aClass");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNotNull();
+    assertThat(timeout.getTimeDate().getRawTextContent()).isEqualTo("2019-09-09T12:12:12");
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutDurationTaskListenerByClassName() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerClassTimeoutWithDuration("timeout-1", "aClass", "PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaClass()).isEqualTo("aClass");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNotNull();
+    assertThat(timeout.getTimeDuration().getRawTextContent()).isEqualTo("PT1H");
+  }
+
+  @Test
+  public void testCamundaTimeoutDurationTaskListenerByClass() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerClassTimeoutWithDuration("timeout-1", this.getClass(), "PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaClass()).isEqualTo(this.getClass().getName());
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNotNull();
+    assertThat(timeout.getTimeDuration().getRawTextContent()).isEqualTo("PT1H");
+  }
+
+  @Test
+  public void testCamundaTimeoutCycleTaskListenerByClass() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerClassTimeoutWithCycle("timeout-1", this.getClass(), "R/PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaClass()).isEqualTo(this.getClass().getName());
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNotNull();
+    assertThat(timeout.getTimeCycle().getRawTextContent()).isEqualTo("R/PT1H");
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutDateTaskListenerByClass() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerClassTimeoutWithDate("timeout-1", this.getClass(), "2019-09-09T12:12:12")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaClass()).isEqualTo(this.getClass().getName());
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNotNull();
+    assertThat(timeout.getTimeDate().getRawTextContent()).isEqualTo("2019-09-09T12:12:12");
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutCycleTaskListenerByExpression() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerExpressionTimeoutWithCycle("timeout-1", "anExpression", "R/PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaExpression()).isEqualTo("anExpression");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNotNull();
+    assertThat(timeout.getTimeCycle().getRawTextContent()).isEqualTo("R/PT1H");
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutDateTaskListenerByExpression() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerExpressionTimeoutWithDate("timeout-1", "anExpression", "2019-09-09T12:12:12")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaExpression()).isEqualTo("anExpression");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNotNull();
+    assertThat(timeout.getTimeDate().getRawTextContent()).isEqualTo("2019-09-09T12:12:12");
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutDurationTaskListenerByExpression() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerExpressionTimeoutWithDuration("timeout-1", "anExpression", "PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaExpression()).isEqualTo("anExpression");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNotNull();
+    assertThat(timeout.getTimeDuration().getRawTextContent()).isEqualTo("PT1H");
+  }
+
+  @Test
+  public void testCamundaTimeoutCycleTaskListenerByDelegateExpression() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerDelegateExpressionTimeoutWithCycle("timeout-1", "aDelegate", "R/PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaDelegateExpression()).isEqualTo("aDelegate");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNotNull();
+    assertThat(timeout.getTimeCycle().getRawTextContent()).isEqualTo("R/PT1H");
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutDateTaskListenerByDelegateExpression() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerDelegateExpressionTimeoutWithDate("timeout-1", "aDelegate", "2019-09-09T12:12:12")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaDelegateExpression()).isEqualTo("aDelegate");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNotNull();
+    assertThat(timeout.getTimeDate().getRawTextContent()).isEqualTo("2019-09-09T12:12:12");
+    assertThat(timeout.getTimeDuration()).isNull();
+  }
+
+  @Test
+  public void testCamundaTimeoutDurationTaskListenerByDelegateExpression() {
+    modelInstance = Bpmn.createProcess()
+        .startEvent()
+          .userTask("task")
+            .camundaTaskListenerDelegateExpressionTimeoutWithDuration("timeout-1", "aDelegate", "PT1H")
+        .endEvent()
+        .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    ExtensionElements extensionElements = userTask.getExtensionElements();
+    Collection<CamundaTaskListener> taskListeners = extensionElements.getChildElementsByType(CamundaTaskListener.class);
+    assertThat(taskListeners).hasSize(1);
+
+    CamundaTaskListener taskListener = taskListeners.iterator().next();
+    assertThat(taskListener.getCamundaDelegateExpression()).isEqualTo("aDelegate");
+    assertThat(taskListener.getCamundaEvent()).isEqualTo("timeout");
+
+    Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
+    assertThat(timeouts.size()).isEqualTo(1);
+
+    TimerEventDefinition timeout = timeouts.iterator().next();
+    assertThat(timeout.getTimeCycle()).isNull();
+    assertThat(timeout.getTimeDate()).isNull();
+    assertThat(timeout.getTimeDuration()).isNotNull();
+    assertThat(timeout.getTimeDuration().getRawTextContent()).isEqualTo("PT1H");
+  }
+
+  @Test
   public void testCamundaExecutionListenerByClassName() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
@@ -2120,7 +2456,7 @@ public class ProcessBuilderTest {
         .boundaryEvent("boundary").error("myErrorCode")
         .endEvent("boundaryEnd")
         .done();
-    
+
     assertErrorEventDefinition("boundary", "myErrorCode", null);
   }
 
@@ -2161,7 +2497,7 @@ public class ProcessBuilderTest {
       .done();
 
     Bpmn.writeModelToStream(System.out, modelInstance);
-    
+
     assertErrorEventDefinition("boundary", "errorCode", "errorMessage");
     assertErrorEventDefinitionForErrorVariables("boundary", "errorCodeVariable", "errorMessageVariable");
   }
@@ -2175,14 +2511,14 @@ public class ProcessBuilderTest {
 
     assertErrorEventDefinition("end", "myErrorCode", "errorMessage");
   }
-  
+
   @Test
   public void testErrorEndEventWithoutErrorMessage() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
         .endEvent("end").error("myErrorCode")
         .done();
-    
+
     assertErrorEventDefinition("end", "myErrorCode", null);
   }
 
@@ -2220,7 +2556,7 @@ public class ProcessBuilderTest {
 
     assertErrorEventDefinition("subProcessStart", "myErrorCode", "errorMessage");
   }
-  
+
   @Test
   public void testErrorStartEventWithoutErrorMessage() {
     modelInstance = Bpmn.createProcess()
@@ -2233,7 +2569,7 @@ public class ProcessBuilderTest {
             .error("myErrorCode")
             .endEvent()
         .done();
-    
+
     assertErrorEventDefinition("subProcessStart", "myErrorCode", null);
   }
 

--- a/src/test/java/org/camunda/bpm/model/bpmn/instance/camunda/CamundaTaskListenerTest.java
+++ b/src/test/java/org/camunda/bpm/model/bpmn/instance/camunda/CamundaTaskListenerTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.camunda.bpm.model.bpmn.instance.BpmnModelElementInstanceTest;
+import org.camunda.bpm.model.bpmn.instance.TimerEventDefinition;
 
 import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_NS;
 
@@ -35,7 +36,8 @@ public class CamundaTaskListenerTest extends BpmnModelElementInstanceTest {
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
     return Arrays.asList(
       new ChildElementAssumption(CAMUNDA_NS, CamundaField.class),
-      new ChildElementAssumption(CAMUNDA_NS, CamundaScript.class, 0, 1)
+      new ChildElementAssumption(CAMUNDA_NS, CamundaScript.class, 0, 1),
+      new ChildElementAssumption(TimerEventDefinition.class, 0, 1)
     );
   }
 

--- a/src/test/resources/org/camunda/bpm/model/bpmn/CamundaExtensionsCompatabilityTest.xml
+++ b/src/test/resources/org/camunda/bpm/model/bpmn/CamundaExtensionsCompatabilityTest.xml
@@ -2,6 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:camunda="http://activiti.org/bpmn"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   targetNamespace="http://camunda.org/test">
 
   <!-- NOTE: this document is not valid and is only used to test all camunda extensions -->
@@ -63,6 +64,9 @@
           <camunda:field name="test">
             <camunda:string>test</camunda:string>
           </camunda:field>
+          <timerEventDefinition>
+            <timeDuration xsi:type="tFormalExpression">PT1H</timeDuration>
+          </timerEventDefinition>
         </camunda:taskListener>
         <camunda:taskListener>
           <camunda:script scriptFormat="groovy" resource="test.groovy" />

--- a/src/test/resources/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.xml
+++ b/src/test/resources/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.xml
@@ -2,6 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   targetNamespace="http://camunda.org/test">
 
   <!-- NOTE: this document is not valid and is only used to test all camunda extensions -->
@@ -63,6 +64,9 @@
           <camunda:field name="test">
             <camunda:string>test</camunda:string>
           </camunda:field>
+          <timerEventDefinition>
+            <timeDuration xsi:type="tFormalExpression">PT1H</timeDuration>
+          </timerEventDefinition>
         </camunda:taskListener>
         <camunda:taskListener>
           <camunda:script scriptFormat="groovy" resource="test.groovy" />


### PR DESCRIPTION
* add event definition as task listener child element
* add builder methods for timeout task listeners in user task builder

related to https://app.camunda.com/jira/browse/CAM-10399
related to https://github.com/camunda/camunda-bpm-platform/pull/453