### PR TITLE
CAM-11160: Allow asynchronous on multi-instance characteristics

### DIFF
--- a/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
+++ b/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
@@ -104,6 +104,26 @@ public class AbstractMultiInstanceLoopCharacteristicsBuilder<B extends AbstractM
   }
 
   /**
+   * Sets the multi instance loop characteristics to be asynchronous before.
+   *
+   * @return  the builder object
+   */
+  public B camundaAsyncBefore() {
+    element.setCamundaAsyncBefore(true);
+    return myself;
+  }
+
+  /**
+   * Sets the multi instance loop characteristics to be asynchronous after.
+   *
+   * @return  the builder object
+   */
+  public B camundaAsyncAfter() {
+    element.setCamundaAsyncAfter(true);
+    return myself;
+  }
+
+  /**
    * Finishes the building of a multi instance loop characteristics.
    *
    * @return the parent activity builder

--- a/src/test/java/org/camunda/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/src/test/java/org/camunda/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -2116,6 +2116,54 @@ public class ProcessBuilderTest {
   }
 
   @Test
+  public void testMultiInstanceLoopCharacteristicsAsynchronousMultiInstanceAsyncBeforeElement() {
+    modelInstance = Bpmn.createProcess()
+            .startEvent()
+            .userTask("task")
+            .multiInstance()
+            .camundaAsyncBefore()
+            .parallel()
+            .multiInstanceDone()
+            .endEvent()
+            .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    Collection<MultiInstanceLoopCharacteristics> miCharacteristics =
+            userTask.getChildElementsByType(MultiInstanceLoopCharacteristics.class);
+
+    assertThat(miCharacteristics).hasSize(1);
+
+    MultiInstanceLoopCharacteristics miCharacteristic = miCharacteristics.iterator().next();
+    assertThat(miCharacteristic.isSequential()).isFalse();
+    assertThat(miCharacteristic.isCamundaAsyncAfter()).isFalse();
+    assertThat(miCharacteristic.isCamundaAsyncBefore()).isTrue();
+  }
+
+  @Test
+  public void testMultiInstanceLoopCharacteristicsAsynchronousMultiInstanceAsyncAfterElement() {
+    modelInstance = Bpmn.createProcess()
+            .startEvent()
+            .userTask("task")
+            .multiInstance()
+            .camundaAsyncAfter()
+            .parallel()
+            .multiInstanceDone()
+            .endEvent()
+            .done();
+
+    UserTask userTask = modelInstance.getModelElementById("task");
+    Collection<MultiInstanceLoopCharacteristics> miCharacteristics =
+            userTask.getChildElementsByType(MultiInstanceLoopCharacteristics.class);
+
+    assertThat(miCharacteristics).hasSize(1);
+
+    MultiInstanceLoopCharacteristics miCharacteristic = miCharacteristics.iterator().next();
+    assertThat(miCharacteristic.isSequential()).isFalse();
+    assertThat(miCharacteristic.isCamundaAsyncAfter()).isTrue();
+    assertThat(miCharacteristic.isCamundaAsyncBefore()).isFalse();
+  }
+
+  @Test
   public void testTaskWithCamundaInputOutputWithExistingExtensionElements() {
     modelInstance = Bpmn.createProcess()
       .startEvent()


### PR DESCRIPTION
[![CAM-11160](https://badgen.net/badge/JIRA/CAM-11160/0052CC)](https://app.camunda.com/jira/browse/CAM-11160)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This feature allows to configure the asynchronous behaviour of element activities of a multi-instance activity from the fluent builder API, in addition to the existing feature to set the asynchronous behaviour for the whole multi-instance body.